### PR TITLE
Proper string escaping and arena deepcopy

### DIFF
--- a/arena_test.go
+++ b/arena_test.go
@@ -2,15 +2,18 @@ package fastjson
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 )
 
-func TestArena(t *testing.T) {
+// Generic test driver that tests both serial and concurrent executions of the test with a given arena
+func testArenaDriver(t *testing.T, iterations int, doTest func(a *Arena) error) {
+	t.Helper()
 	t.Run("serial", func(t *testing.T) {
 		var a Arena
-		for i := 0; i < 10; i++ {
-			if err := testArena(&a); err != nil {
+		for i := 0; i < iterations; i++ {
+			if err := doTest(&a); err != nil {
 				t.Fatal(err)
 			}
 			a.Reset()
@@ -18,15 +21,18 @@ func TestArena(t *testing.T) {
 	})
 	t.Run("concurrent", func(t *testing.T) {
 		var ap ArenaPool
-		workers := 4
+		workers := 128
 		ch := make(chan error, workers)
 		for i := 0; i < workers; i++ {
 			go func() {
 				a := ap.Get()
-				defer ap.Put(a)
+				defer func() {
+					a.Reset()
+					ap.Put(a)
+				}()
 				var err error
-				for i := 0; i < 10; i++ {
-					if err = testArena(a); err != nil {
+				for i := 0; i < iterations; i++ {
+					if err = doTest(a); err != nil {
 						break
 					}
 				}
@@ -39,11 +45,15 @@ func TestArena(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-			case <-time.After(time.Second):
+			case <-time.After(time.Second * 3):
 				t.Fatalf("timeout")
 			}
 		}
 	})
+}
+
+func TestArena(t *testing.T) {
+	testArenaDriver(t, 1000, func(a *Arena) error { return testArena(a) })
 }
 
 func testArena(a *Arena) error {
@@ -56,6 +66,7 @@ func testArena(a *Arena) error {
 	o.Set("ni", ni)
 	o.Set("nf", a.NewNumberFloat64(1.23))
 	o.Set("ns", a.NewNumberString("34.43"))
+	o.Set("nbs", a.NewNumberStringBytes(s2b("-98.765")))
 	s := a.NewString("foo")
 	o.Set("str1", s)
 	o.Set("str2", a.NewStringBytes([]byte("xx")))
@@ -69,9 +80,60 @@ func testArena(a *Arena) error {
 	o.Set("obj", obj)
 
 	str := o.String()
-	strExpected := `{"nil1":null,"nil2":null,"false":false,"true":true,"ni":123,"nf":1.23,"ns":34.43,"str1":"foo","str2":"xx","a":["foo",123],"obj":{"s":"foo"}}`
+	strExpected := `{"nil1":null,"nil2":null,"false":false,"true":true,"ni":123,"nf":1.23,"ns":34.43,"nbs":-98.765,"str1":"foo","str2":"xx","a":["foo",123],"obj":{"s":"foo"}}`
 	if str != strExpected {
 		return fmt.Errorf("unexpected json\ngot\n%s\nwant\n%s", str, strExpected)
+	}
+	return nil
+}
+
+func TestArenaDeepCopyValue(t *testing.T) {
+	testArenaDriver(t, 100, func(a *Arena) error { return testArenaDeepCopyValue(a) })
+}
+
+func randValidChar() rune {
+	for {
+		c := rune('0' + rand.Intn(78))
+		if c != '\\' {
+			return c
+		}
+	}
+}
+
+func testArenaDeepCopyValue(a *Arena) error {
+	const jsonTest = `{"nil":null,"false":false,"true":true,"ni":123,"nf":1.23,"ns":34.43,"nbs":-98.765,"str1":"foo","str2":"xx","a":["foo",123,{"s":"x","n":-1.0,"o":{},"nil":null}],"obj":{"s":"foo","a":[123,"s",{"f":{"f2":"v","f3":{"a":98}}}]}}`
+	// Use a locally controlled parser that we'll reset and reuse to ensure the deep copy truly copied all the values
+	var p Parser
+	tempValue, err := p.Parse(jsonTest)
+	if err != nil {
+		return fmt.Errorf("failed to parse test json: %w", err)
+	}
+	// Validate that the serialized value matches the original test
+	tempSerialized := b2s(tempValue.MarshalTo(nil))
+	if tempSerialized != jsonTest {
+		return fmt.Errorf("initial parsed test JSON does not match\ngot\n%s\nwant\n%s", tempSerialized, jsonTest)
+	}
+	// Do a deep copy to preserve the values after the parser is reused
+	shallowCopy := tempValue
+	deepCopy := a.DeepCopyValue(tempValue)
+	// Now reuse the parser enough times so it should trash a shallow copy
+	for i := 0; i < 100; i++ {
+		rn := rand.Int63n(2 ^ 40)
+		rs := fmt.Sprintf("%c%d%d%c", randValidChar(), rand.Int63(), rand.Int63(), randValidChar())
+		mixerJSON := fmt.Sprintf(`{"n1":%d,"s1":"%s","o1":{"a1":[%d,true,%d,false,"%s",{"f1":%d,"f2":[%d,%d,[%d,"%s"]]}]}}`, rn, rs, rn, rn, rs, rn, rn, rn, rn, rs)
+		_, err = p.Parse(mixerJSON)
+		if err != nil {
+			return fmt.Errorf("failed reusing parser to parser random JSON: %w\nJSON\n%s", err, mixerJSON)
+		}
+	}
+	// Now check that the deep copy is good and the shallow copy is bad
+	deepCopyJSON := b2s(deepCopy.MarshalTo(nil))
+	if deepCopyJSON != jsonTest {
+		return fmt.Errorf("deep copy JSON does not match\ngot\n%s\nwant\n%s", deepCopyJSON, jsonTest)
+	}
+	shallowCopyJSON := b2s(shallowCopy.MarshalTo(nil))
+	if shallowCopyJSON == jsonTest {
+		return fmt.Errorf("shallow copy JSON matches when it should not match!\nshallow_copy\n%s", shallowCopyJSON)
 	}
 	return nil
 }

--- a/parser.go
+++ b/parser.go
@@ -267,28 +267,35 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
-	if !hasSpecialChars(s) {
-		// Fast path - nothing to escape.
-		dst = append(dst, '"')
-		dst = append(dst, s...)
-		dst = append(dst, '"')
-		return dst
-	}
-
-	// Slow path.
-	return strconv.AppendQuote(dst, s)
-}
-
-func hasSpecialChars(s string) bool {
-	if strings.IndexByte(s, '"') >= 0 || strings.IndexByte(s, '\\') >= 0 {
-		return true
-	}
 	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 {
-			return true
+		c := s[i]
+		switch {
+		case c == 0x22:
+			// quotation mark
+			dst = append(dst, []byte{92, 34}...)
+		case c == 0x5c:
+			// reverse solidus
+			dst = append(dst, []byte{92, 92}...)
+		case c >= 0x20:
+			// default, rest are control chars
+			dst = append(dst, c)
+		case c < 0x09:
+			dst = append(dst, []byte{92, 117, 48, 48, 48 + c, 48}...)
+		case c == 0x09:
+			dst = append(dst, []byte{92, 116}...)
+		case c == 0x0a:
+			dst = append(dst, []byte{92, 110}...)
+		case c == 0x0d:
+			dst = append(dst, []byte{92, 114}...)
+		case c < 0x10:
+			dst = append(dst, []byte{92, 117, 48, 48, 87 + c, 48}...)
+		case c < 0x1a:
+			dst = append(dst, []byte{92, 117, 48, 49, 32 + c, 48}...)
+		case c < 0x20:
+			dst = append(dst, []byte{92, 117, 48, 49, 71 + c, 48}...)
 		}
 	}
-	return false
+	return dst
 }
 
 func unescapeStringBestEffort(s string) string {

--- a/parser.go
+++ b/parser.go
@@ -323,6 +323,8 @@ func unescapeStringBestEffort(s string) string {
 			b = append(b, '"')
 		case '\\':
 			b = append(b, '\\')
+		case '/':
+			b = append(b, '/')
 		case 'b':
 			b = append(b, '\b')
 		case 'f':

--- a/parser.go
+++ b/parser.go
@@ -281,7 +281,7 @@ func escapeString(dst []byte, s string) []byte {
 			// default, rest are control chars
 			dst = append(dst, c)
 		case c < 0x09:
-			dst = append(dst, []byte{92, 117, 48, 48, 48 + c, 48}...)
+			dst = append(dst, []byte{92, 117, 48, 48, 48, 48 + c}...)
 		case c == 0x09:
 			dst = append(dst, []byte{92, 116}...)
 		case c == 0x0a:
@@ -289,11 +289,11 @@ func escapeString(dst []byte, s string) []byte {
 		case c == 0x0d:
 			dst = append(dst, []byte{92, 114}...)
 		case c < 0x10:
-			dst = append(dst, []byte{92, 117, 48, 48, 87 + c, 48}...)
+			dst = append(dst, []byte{92, 117, 48, 48, 48, 87 + c}...)
 		case c < 0x1a:
-			dst = append(dst, []byte{92, 117, 48, 49, 32 + c, 48}...)
+			dst = append(dst, []byte{92, 117, 48, 48, 49, 32 + c}...)
 		case c < 0x20:
-			dst = append(dst, []byte{92, 117, 48, 49, 71 + c, 48}...)
+			dst = append(dst, []byte{92, 117, 48, 48, 49, 71 + c}...)
 		}
 	}
 	dst = append(dst, 34)

--- a/parser.go
+++ b/parser.go
@@ -323,8 +323,6 @@ func unescapeStringBestEffort(s string) string {
 			b = append(b, '"')
 		case '\\':
 			b = append(b, '\\')
-		case '/':
-			b = append(b, '/')
 		case 'b':
 			b = append(b, '\b')
 		case 'f':

--- a/parser.go
+++ b/parser.go
@@ -267,36 +267,40 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
-	dst = append(dst, 34)
+	dst = append(dst, '"')
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
-		case c == 0x22:
+		case c == '"':
 			// quotation mark
-			dst = append(dst, []byte{92, 34}...)
-		case c == 0x5c:
+			dst = append(dst, []byte{'\\', '"'}...)
+		case c == '\\':
 			// reverse solidus
-			dst = append(dst, []byte{92, 92}...)
+			dst = append(dst, []byte{'\\', '\\'}...)
 		case c >= 0x20:
-			// default, rest are control chars
+			// default, rest below are control chars
 			dst = append(dst, c)
+		case c == 0x08:
+			dst = append(dst, []byte{'\\', 'b'}...)
 		case c < 0x09:
-			dst = append(dst, []byte{92, 117, 48, 48, 48, 48 + c}...)
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', '0' + c}...)
 		case c == 0x09:
-			dst = append(dst, []byte{92, 116}...)
+			dst = append(dst, []byte{'\\', 't'}...)
 		case c == 0x0a:
-			dst = append(dst, []byte{92, 110}...)
+			dst = append(dst, []byte{'\\', 'n'}...)
+		case c == 0x0c:
+			dst = append(dst, []byte{'\\', 'f'}...)
 		case c == 0x0d:
-			dst = append(dst, []byte{92, 114}...)
+			dst = append(dst, []byte{'\\', 'r'}...)
 		case c < 0x10:
-			dst = append(dst, []byte{92, 117, 48, 48, 48, 87 + c}...)
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', 0x57 + c}...)
 		case c < 0x1a:
-			dst = append(dst, []byte{92, 117, 48, 48, 49, 32 + c}...)
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x20 + c}...)
 		case c < 0x20:
-			dst = append(dst, []byte{92, 117, 48, 48, 49, 71 + c}...)
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x47 + c}...)
 		}
 	}
-	dst = append(dst, 34)
+	dst = append(dst, '"')
 	return dst
 }
 

--- a/parser.go
+++ b/parser.go
@@ -267,6 +267,7 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
+	dst = append(dst, 34)
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
@@ -295,6 +296,7 @@ func escapeString(dst []byte, s string) []byte {
 			dst = append(dst, []byte{92, 117, 48, 49, 71 + c, 48}...)
 		}
 	}
+	dst = append(dst, 34)
 	return dst
 }
 

--- a/parser.go
+++ b/parser.go
@@ -2,10 +2,11 @@ package fastjson
 
 import (
 	"fmt"
-	"github.com/aperturerobotics/fastjson/fastfloat"
 	"strconv"
 	"strings"
 	"unicode/utf16"
+
+	"github.com/aperturerobotics/fastjson/fastfloat"
 )
 
 // Parser parses JSON.
@@ -897,6 +898,19 @@ func (v *Value) GetUint64(keys ...string) uint64 {
 		return 0
 	}
 	return fastfloat.ParseUint64BestEffort(v.s)
+}
+
+// GetNumberAsStringBytes returns string representation of the numeric value by the given keys path.
+//
+// Array indexes may be represented as decimal numbers in keys.
+//
+// nil is returned for non-existing keys path or for invalid value type.
+func (v *Value) GetNumberAsStringBytes(keys ...string) []byte {
+	v = v.Get(keys...)
+	if v == nil || v.Type() != TypeNumber {
+		return nil
+	}
+	return s2b(v.s)
 }
 
 // GetStringBytes returns string value by the given keys path.

--- a/parser_test.go
+++ b/parser_test.go
@@ -314,7 +314,8 @@ func TestValueGetTyped(t *testing.T) {
 		"zero_float2": -0e123,
 		"inf_float": Inf,
 		"minus_inf_float": -Inf,
-		"nan": nan
+		"nan": nan,
+		"tiny_number": 0.0000000005
 	}`)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -360,7 +361,7 @@ func TestValueGetTyped(t *testing.T) {
 		t.Fatalf("unexpected value; got %d; want %d", n, 123)
 	}
 	n64 := v.GetInt64("foo")
-	if n != 123 {
+	if n64 != 123 {
 		t.Fatalf("unexpected value; got %d; want %d", n64, 123)
 	}
 	un := v.GetUint("foo")
@@ -371,21 +372,29 @@ func TestValueGetTyped(t *testing.T) {
 	if un != 123 {
 		t.Fatalf("unexpected value; got %d; want %d", un64, 123)
 	}
+	nstr := v.GetNumberAsStringBytes("foo")
+	if b2s(nstr) != "123" {
+		t.Fatalf("unexpected value; got %s; want %s", nstr, "123")
+	}
 	n = v.GetInt("bar")
 	if n != 0 {
 		t.Fatalf("unexpected non-zero value; got %d", n)
 	}
 	n64 = v.GetInt64("bar")
-	if n != 0 {
+	if n64 != 0 {
 		t.Fatalf("unexpected non-zero value; got %d", n64)
 	}
 	un = v.GetUint("bar")
-	if n != 0 {
+	if un != 0 {
 		t.Fatalf("unexpected non-zero value; got %d", un)
 	}
 	un64 = v.GetUint64("bar")
-	if n != 0 {
+	if un64 != 0 {
 		t.Fatalf("unexpected non-zero value; got %d", un64)
+	}
+	nstr = v.GetNumberAsStringBytes("bar")
+	if nstr != nil {
+		t.Fatalf("unexpected non-nil value; got %d", nstr)
 	}
 	f := v.GetFloat64("foo")
 	if f != 123.0 {
@@ -463,6 +472,11 @@ func TestValueGetTyped(t *testing.T) {
 	}
 	if !math.IsNaN(nanf) {
 		t.Fatalf("unexpected nan value: %f. Expecting %f", nanf, math.NaN())
+	}
+
+	tiny_number := v.GetNumberAsStringBytes("tiny_number")
+	if b2s(tiny_number) != "0.0000000005" {
+		t.Fatalf("unexpected tiny_number value; got %s; want %s", tiny_number, "0.0000000005")
 	}
 }
 

--- a/pool.go
+++ b/pool.go
@@ -44,7 +44,9 @@ func (ap *ArenaPool) Get() *Arena {
 	return v.(*Arena)
 }
 
-// Put returns a to ap.
+// Put returns a to ap. This does not automatically reset the Arena.
+// You should either Reset the arena before putting it back into the
+// pool, or you should Reset any arena you get back from Get.
 //
 // a and objects created by a cannot be used after a is put into ap.
 func (ap *ArenaPool) Put(a *Arena) {


### PR DESCRIPTION
* Merged the fix to string escape during serialization from https://github.com/valyala/fastjson/pull/87 (thanks @barkyq!)
* Added unit tests to ensure string escape exactly matches standard library behavior (no bugs found)
* Added Arena.DeepCopyValue, which can be used to change the lifecycle of a Value (e.g., to extend the lifetime of a Value returned by Scanner)
* Added Arena.NewNumberStringBytes function - creates a new number from the arena storing the string bytes data inside the arena - can be useful by those already managing values and arena scope carefully to store other related string data
* Added Arena.AllocateStringFromStringBytes function to allocate and copy arbitrary string bytes data into the arena
* Clarified instructions for ArenaPool.Put to make sure callers get the benefit that they expect
* Made concurrent tests for Arena more rigorous and refactored into a generic test driver
* Small fixups to existing unit tests